### PR TITLE
Konfigurieren der MongoDB Verbindung mit Mongoose

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 ## Installationguide
 - If not already installed, you need to install Node.js first
 - Then use npm to install bower: $ npm install -g --save bower
+- You need to install mongodb version ^3.2.3 and configure it correct
+- if mongodb is not already running, start it with: $ mongod --conf /path/to/mongod.conf
 - To install needed backend dependencies change in this directory and call $ npm install
-- To install needed frontend dependencies change in this directory and call $ bower install 
+- To install needed frontend dependencies change in this directory and call $ bower install
 - To start the http server you need to call $ npm start

--- a/app.js
+++ b/app.js
@@ -3,6 +3,7 @@ const http = require('http');
 const nconf = require('nconf');
 const debug = require('debug')('server:app');
 const path = require('path');
+const mongoose = require('mongoose');
 
 const app = express();
 const server = http.createServer(app);
@@ -14,6 +15,7 @@ nconf
     file: './config.json'
   });
 
+const db_url = nconf.get('DB_URL');
 const webOptions = {
   port: nconf.get('WEB_PORT'),
   host: nconf.get('WEB_HOST')
@@ -21,6 +23,13 @@ const webOptions = {
 
 app.use(express.static(path.join(__dirname, 'public')));
 
-server.listen(webOptions, function listeningCallback() {
-  debug('server listen on: ', server.address());
+debug('Try to establish mongdb connection on: ' + db_url);
+mongoose.connect(db_url);
+const db = mongoose.connection;
+db.on('error', console.error.bind(console, 'mongodb connection error:'));
+db.once('open', () => {
+  debug('mongodb connection succesful established.');
+  server.listen(webOptions, function listeningCallback() {
+    debug('server listen on: ', server.address());
+  });
 });

--- a/app.js
+++ b/app.js
@@ -28,7 +28,7 @@ mongoose.connect(db_url);
 const db = mongoose.connection;
 db.on('error', console.error.bind(console, 'mongodb connection error:'));
 db.once('open', () => {
-  debug('mongodb connection succesful established.');
+  debug('mongodb connection successful established.');
   server.listen(webOptions, function listeningCallback() {
     debug('server listen on: ', server.address());
   });

--- a/config.json
+++ b/config.json
@@ -1,4 +1,5 @@
 {
   "WEB_PORT": 8000,
-  "WEB_HOST": "localhost"
+  "WEB_HOST": "localhost",
+  "DB_URL": "mongodb://localhost/treetalk"
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "bootstrap": "^3.3.6",
     "debug": "^2.2.0",
     "express": "^4.13.4",
+    "mongoose": "^4.4.10",
     "nconf": "^0.8.4"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,10 @@
     "type": "git",
     "url": "git+https://github.com/S3bastianGriesa/treetalk.git"
   },
-  "author": "Sebastian Griesa",
+  "authors": [
+    "Julian Biermann",
+    "Sebastian Griesa"
+  ],
   "license": "ISC",
   "bugs": {
     "url": "https://github.com/S3bastianGriesa/treetalk/issues"


### PR DESCRIPTION
Hinweise zur MongoDB wurden der Readme hinzugefügt. Installation und Konfiguration von MongoDB muss jeder Anwender, der den Server starten will, bei sich lokal vornehmen. Es wurde sichergestellt, dass der HTTP-Server nun nur noch startet, wenn eine Verbindung zur MongoDB hergestellt werden konnte. Die Verbindung zur MongoDB ist in der config.json hinterlegt. Es sollte versucht werden bei allen Datenbankvorgängen über den OR-Mapper Mongoose zu arbeiten.
