### PR TITLE
Feature/treet 30 add deployment script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,6 @@ build/Release
 
 public/components
 
+deploy/inventory
+
 config.json

--- a/app.js
+++ b/app.js
@@ -1,3 +1,4 @@
+require('strict-mode')(function() {
 const express = require('express');
 const http = require('http');
 const nconf = require('nconf');
@@ -66,4 +67,5 @@ app.get('/app/chat', authentication.middleware.requiresLogin, (req, res) => {
     res.sendFile('chat.html', {
         root: './public'
     });
+});
 });

--- a/deploy/ansible.cfg
+++ b/deploy/ansible.cfg
@@ -1,5 +1,5 @@
 [defaults]
-hostfile = inventory
+hostfile = ~/deploy/treetalk/inventory
 host_key_checking = False
 pipelining = True
 ssh_args = -o

--- a/deploy/ansible.cfg
+++ b/deploy/ansible.cfg
@@ -1,0 +1,6 @@
+[defaults]
+hostfile = inventory
+host_key_checking = False
+pipelining = True
+ssh_args = -o
+ForwardAgent=yes

--- a/deploy/build.yml
+++ b/deploy/build.yml
@@ -1,0 +1,16 @@
+- name: Install forever globally over NPM
+  npm: >
+        name=forever
+        global=yes
+        state=present
+  become: true
+  become_method: sudo
+
+- name: rebuild npm modules
+  shell: npm rebuild
+  args:
+    chdir: '{{ dest_path }}/treetalk'
+  register: npm_rebuild_feedback
+  become: true
+  become_method: sudo
+- debug: var=npm_rebuild_feedback.stdout

--- a/deploy/build.yml
+++ b/deploy/build.yml
@@ -6,6 +6,14 @@
   become: true
   become_method: sudo
 
+- name: Install bower globally over NPM
+  npm: >
+        name=bower
+        global=yes
+        state=present
+  become: true
+  become_method: sudo
+
 - name: rebuild npm modules
   shell: npm rebuild
   args:
@@ -14,3 +22,10 @@
   become: true
   become_method: sudo
 - debug: var=npm_rebuild_feedback.stdout
+
+- name: rebuild bower modules
+  shell: bower rebuild
+  args:
+    chdir: '{{ dest_path }}/treetalk'
+  register: bower_rebuild_feedback
+- debug: var=bower_rebuild_feedback.stdout

--- a/deploy/deploy-repository.yml
+++ b/deploy/deploy-repository.yml
@@ -1,0 +1,55 @@
+- debug: msg="Copy from local/{{ src_path }} to remote/{{ dest_path }}"
+
+- name: zip content on local host
+  local_action: shell tar -czf {{ zip_name }} {{ project_name }}
+  run_once: true
+  args:
+    chdir: "{{ src_path }}"
+
+- name: clean up directory on remote host
+  file: >
+        path={{ dest_path }}
+        state=absent
+  become: true
+  become_method: sudo
+
+- name: create path on remote host
+  file: >
+        path={{ dest_path }}
+        state=directory
+  become: true
+  become_method: sudo
+
+- name: copy zip to remote host
+  copy: >
+        src={{ src_path }}/{{ zip_name }}
+        dest={{ dest_path }}
+  become: true
+  become_method: sudo
+
+- name: unzip content on remote host
+  shell: gunzip {{ zip_name }}
+  args:
+    chdir: "{{ dest_path }}"
+  become: true
+  become_method: sudo
+
+- name: unzip content on remote host
+  shell: tar -xvf {{ tar_name }}
+  args:
+    chdir: "{{ dest_path }}"
+  become: true
+  become_method: sudo
+
+- name: remove zip on local host
+  local_action: shell rm {{ zip_name }}
+  run_once: true
+  args:
+    chdir: "{{ src_path }}"
+
+- name: remove zip on remote host
+  file: >
+        path={{ dest_path }}/{{ zip_name }}
+        state=absent
+  become: true
+  become_method: sudo

--- a/deploy/main.yml
+++ b/deploy/main.yml
@@ -3,6 +3,8 @@
   remote_user: "{{ remote_user }}"
   tasks:
       - debug: msg="Distribution on remotesystem {{ ansible_distribution }}"
+      - include: stop-server.yml
       - include: deploy-repository.yml
       - include: setup-configuration.yml
       - include: build.yml
+      - include: start-server.yml

--- a/deploy/main.yml
+++ b/deploy/main.yml
@@ -1,0 +1,8 @@
+- name: Deploy Treetalk
+  hosts: development
+  remote_user: "{{ remote_user }}"
+  tasks:
+      - debug: msg="Distribution on remotesystem {{ ansible_distribution }}"
+      - include: deploy-repository.yml
+      - include: setup-configuration.yml
+      - include: build.yml

--- a/deploy/setup-configuration.yml
+++ b/deploy/setup-configuration.yml
@@ -1,0 +1,7 @@
+- name: Generate and copy template for config
+  template: >
+              src=template/config.json.j2
+              dest={{ dest_path }}/{{ config_template_dest }}
+              mode=0644
+  become: true
+  become_method: sudo

--- a/deploy/start-server.yml
+++ b/deploy/start-server.yml
@@ -1,0 +1,6 @@
+- name: Start server with forever
+  shell: forever start app.js
+  args:
+    chdir: "{{ dest_path }}/{{ project_name }}"
+  become: true
+  become_method: sudo

--- a/deploy/stop-server.yml
+++ b/deploy/stop-server.yml
@@ -1,0 +1,4 @@
+- name: Stop server with forever
+  shell: forever stopall
+  become: true
+  become_method: sudo

--- a/deploy/template/config.json.j2
+++ b/deploy/template/config.json.j2
@@ -1,0 +1,6 @@
+{
+  "WEB_PORT": {{ webport }},
+  "WEB_HOST": "{{ webhost }}",
+  "DB_URL": "{{ mongodb_url }}",
+  "SESSION_SECRET": "{{ secret }}"
+}

--- a/package.json
+++ b/package.json
@@ -5,23 +5,24 @@
   "main": "app.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "npm update && node --use_strict app.js"
+    "start": "npm update && node app.js"
   },
   "dependencies": {
     "authentication": "file:modules\\authentication",
     "body-parser": "^1.15.0",
     "bootstrap": "^3.3.6",
     "connect-mongo": "^1.1.0",
+    "crypto-util": "file:./modules/crypto-util",
     "debug": "^2.2.0",
     "express": "^4.13.4",
     "express-session": "^1.13.0",
     "login": "file:modules\\login",
     "mongoose": "^4.4.10",
     "nconf": "^0.8.4",
-    "uid-safe": "^2.1.0",
-    "user": "file:./modules/user",
     "registration": "file:./modules/registration",
-    "crypto-util": "file:./modules/crypto-util"
+    "strict-mode": "^0.5.0",
+    "uid-safe": "^2.1.0",
+    "user": "file:./modules/user"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Automatische deploymentskripte wurden hinzugefügt. Um diese zu nutzen muss eine Inventory File in ~/deploy/treetalk/ existieren und richtig konfiguriert sein. Die Inventory File wird nicht Teil des Repositories sein, da sie sensible Daten (Zugangsdaten, Passwörter) enthält. Wer deployen möchte sagt mir bescheid und ich reiche eine Kopie der Inventory File weiter. Vorher sollte man sich noch die Erlaubnis von Thorben holen, da es sein Server ist.. (Wegen der Zugangsdaten).

Ausserdem wurde das Modul 'strict-mode' hinzugefügt, da sonst der Serverstart mit Forever nicht funktioniert. Das Modul sorgt lediglich dafür, dass Node komplett in strict mode läuft.
